### PR TITLE
Dashboard charts

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -140,9 +140,13 @@ case 'nrrd':
     break;
 case 'DICOMTAR':
     // ADD case for DICOMTAR
-    $FullPath         = $imagePath . '/' . $File;
+    $FullPath         = $tarchivePath . '/' . $File;
     $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
+    $saveAs           = $_GET['saveAs'];
+    if (strpos($saveAs, ".tar") === false) {
+        $saveAs = $DownloadFilename;
+    }
     break;
 default:
     $FullPath         = $DownloadPath . '/' . $File;
@@ -150,9 +154,6 @@ default:
     $DownloadFilename = basename($File);
     break;
 }
-
- print "$FullPath";
- print "$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");
@@ -163,7 +164,13 @@ if (!file_exists($FullPath)) {
 header("Content-type: $MimeType");
 if (!empty($DownloadFilename)) {
 
-    header("Content-Disposition: attachment; filename=$DownloadFilename");
+    if ($FileExt === 'DICOMTAR' && !empty($saveAs)) {
+        header("Content-Disposition: attachment; filename=$saveAs");
+
+    } else {
+
+        header("Content-Disposition: attachment; filename=$DownloadFilename");
+    }
 }
 $fp = fopen($FullPath, 'r');
 fpassthru($fp);

--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -44,7 +44,7 @@
                 </div>
             </div>
             <div class="panel-body">
-                <div class="recruitment-panel hidden" id="recruitment-site-breakdown">
+                <div class="recruitment-panel" id="recruitment-site-breakdown">
                     {if $recruitment['overall']['total_recruitment'] neq 0}
                         <div class="col-lg-4 col-md-4 col-sm-4">
                             <div>

--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -35,8 +35,7 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu pull-right" role="menu">
-                            <li class="active"><a data-target="overall-recruitment">View overall recruitment</a></li>
-                            <li><a data-target="recruitment-site-breakdown">View site breakdown</a></li>
+                            <li class="active"><a data-target="recruitment-site-breakdown">View site breakdown</a></li>
                             {if $useProjects eq "true"}
                                 <li><a data-target="recruitment-project-breakdown">View project breakdown</a></li>
                             {/if}
@@ -45,9 +44,6 @@
                 </div>
             </div>
             <div class="panel-body">
-                <div class="recruitment-panel" id="overall-recruitment">
-                    {include file='progress_bar.tpl' project=$recruitment["overall"]}
-                </div>
                 <div class="recruitment-panel hidden" id="recruitment-site-breakdown">
                     {if $recruitment['overall']['total_recruitment'] neq 0}
                         <div class="col-lg-4 col-md-4 col-sm-4">
@@ -69,9 +65,7 @@
                 {if $useProjects eq "true"}
                     <div class="recruitment-panel hidden" id="recruitment-project-breakdown">
                         {foreach from=$recruitment key=ID item=project}
-                            {if $ID != "overall"}
-                                {include file='progress_bar.tpl' project=$project}
-                            {/if}
+                            {include file='progress_bar.tpl' project=$project}
                         {/foreach}
                     </div>
                 {/if}

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -104,20 +104,52 @@ class Imaging_Session_ControlPanel
         );
         $subjectData['tarchiveids'] = $tarchiveIDs;
 
-
-// To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
+        // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
         $qresult = $DB->pselect(
-            "SELECT TarchiveID, ArchiveLocation
-            FROM tarchive
-            WHERE PatientName LIKE $ID",
+            "SELECT t.TarchiveID, t.ArchiveLocation, 
+                SUBSTRING_INDEX(mu.UploadLocation, '/', -1) AS originalFileName,
+                t.PatientName
+            FROM tarchive t LEFT JOIN mri_upload mu ON t.PatientName=mu.PatientName 
+            WHERE t.PatientName LIKE $ID",
             $params
         );
-        $tarIDTotarLoc=array();
-        foreach($qresult as $k=>$v) {
-            $tarchiveID = $v['TarchiveID'];
-            $tarIDTotarLoc[$tarchiveID]=$v['ArchiveLocation'];
+
+        $tarIDToTarLoc =array();
+        foreach ($qresult as $v) {
+            $tarchiveID       = $v['TarchiveID'];
+            $originalFileName = $v['originalFileName'];
+            $archiveLocation  = $v['ArchiveLocation'];
+            $patientName      = $v['PatientName'];
+            $tarIDToTarLoc[$tarchiveID]['ArchiveLocation']  = $archiveLocation;
+            $tarIDToTarLoc[$tarchiveID]['originalFileName'] = $originalFileName;
+            $tarIDToTarLoc[$tarchiveID]['PatientName']      = $patientName;
+            $originalFileNameParts = explode('_', $originalFileName);
+            if (!empty($originalFileName) && count($originalFileNameParts) == 5
+                && preg_match(
+                    "/^([0-9]{9}).zip/i",
+                    $originalFileNameParts[4],
+                    $matches
+                )) {
+                $patientNameAndDate = implode(
+                    '_',
+                    array_slice(
+                        $originalFileNameParts,
+                        0,
+                        4
+                    )
+                );
+                $timestamp          = substr($matches[1], 0, 4);
+                $dicomFileName      = substr($archiveLocation, 20);
+                $saveAs = $patientNameAndDate.'_'.$timestamp.'_'.$dicomFileName;
+
+            } else {
+                $saveAs = $patientName .'_'.substr($archiveLocation, 5);
+
+            }
+            $tarIDToTarLoc[$tarchiveID]['saveAs'] = $saveAs;
+
         }
-        $subjectData['tarchiveIDLoc']   = $tarIDTotarLoc;
+        $subjectData['tarchiveIDLoc'] = $tarIDTotarLoc;
 
         $config =& \NDB_Config::singleton();
 

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -40,8 +40,8 @@
         {/if}
         {foreach from=$subject.tarchiveIDLoc key=tarchive item=tarchiveLoc}
           <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive}</a></li>
-          <li><a href="/mri/jiv/get_file.php?file=tarchive/{$tarchiveLoc}" class="btn btn-primary btn-small">
-                  <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM {$tarchive}</span>
+          <li><a href="/mri/jiv/get_file.php?file={$tarchiveLoc['ArchiveLocation']}&saveAs={$tarchiveLoc['saveAs']}" class="btn btn-primary btn-small">
+		<span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM {$tarchive}</span>
           </a></li>
         {/foreach}
 <!-- 


### PR DESCRIPTION
Changing default chart tab to be `project breakdown` instead of `overall recruitment`. Removed the overall recruitment tab, and shifted that bar chart to be displayed under the project breakdown tab.