### PR TITLE
Fixing a bug that corrupted files upon download

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -151,8 +151,6 @@ default:
     break;
 }
 
- print "$FullPath";
- print "$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");


### PR DESCRIPTION
Somehow print statements were present in the get_file.php, resulting into those being part of stdout, corrupting any file that would be fetched using get_file.php.
This PR removes those two statements.
