### PR TITLE
Download dicom tar file with a different name

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -151,8 +151,6 @@ default:
     break;
 }
 
- print "$FullPath";
- print "$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -143,6 +143,13 @@ case 'DICOMTAR':
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
+    $saveAs           = preg_replace("/[^a-zA-Z0-9._-]/", "", $_GET['saveAs']);
+    if (strpos($saveAs, ".tar") === false || !in_array(
+        $saveAs,
+        $_SESSION['State']->getProperty('tarIDToTarLoc')
+    )) {
+        $saveAs = $DownloadFilename;
+    }
     break;
 default:
     $FullPath         = $DownloadPath . '/' . $File;
@@ -150,7 +157,6 @@ default:
     $DownloadFilename = basename($File);
     break;
 }
-
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");
@@ -161,7 +167,11 @@ if (!file_exists($FullPath)) {
 header("Content-type: $MimeType");
 if (!empty($DownloadFilename)) {
 
-    header("Content-Disposition: attachment; filename=$DownloadFilename");
+    if ($FileExt === 'DICOMTAR' && !empty($saveAs)) {
+        header("Content-Disposition: attachment; filename=$saveAs");
+    } else {
+        header("Content-Disposition: attachment; filename=$DownloadFilename");
+    }
 }
 $fp = fopen($FullPath, 'r');
 fpassthru($fp);

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -148,7 +148,11 @@ case 'DICOMTAR':
         $saveAs,
         $_SESSION['State']->getProperty('tarIDToTarLoc')
     )) {
-        $saveAs = $DownloadFilename;
+        //$saveAs = $DownloadFilename;
+	error_log("ERROR: Value saveAs $saveAs has been modified.");
+	header("HTTP/1.1 400 Bad Request");
+	exit(5);
+	
     }
     break;
 default:
@@ -161,7 +165,7 @@ default:
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");
     header("HTTP/1.1 404 Not Found");
-    exit(5);
+    exit(6);
 }
 
 header("Content-type: $MimeType");


### PR DESCRIPTION
This PR is associated with the PR on the CAP repo https://github.com/aces/CAP/pull/206.

It fetches the name a dicom tar file should be downloaded as, sanitizes the input, and allows the file to be renamed to that when the user is downloading it.