### PR TITLE
Fixing description and comment field appends for json instruments

### DIFF
--- a/jsx/lib/localize-instrument.js
+++ b/jsx/lib/localize-instrument.js
@@ -18,7 +18,7 @@ function localizeInstrument(rawInstrument, lang = 'en-ca') {
 
     instrument['Elements'].forEach((element) => {
       if (['label', 'text', 'calc', 'date', 'select', 'radio', 'checkbox', 'numeric'].includes(element.Type)) {
-        if (element['Description'][lang] && element['Description'][lang] !== " " && element['Comment']) {
+        if (element['Description'][lang] && (element['Description'][lang] !== " " && element['Description'][lang] !== "  " && element['Description'][lang] !== "   ") && element['Comment']) {
           element['Description'] = fixhtml(element['Description'][lang]) + "; " + fixhtml(element['Comment']);
         } else if (element['Description'][lang] && element['Description'][lang] !== " " && !element['Comment']) {
           element['Description'] = element['Description'][lang];


### PR DESCRIPTION
Some fields have multiple spaces in them for some reason and were not being parsed properly